### PR TITLE
Resolve issue where rebuilds were over-eager.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,17 +20,24 @@ class MainPage extends StatefulWidget {
 class _MainPageState extends State<MainPage> {
   int _index = 0;
 
+  final indexStackKey = GlobalKey();
+
+  final page1Key = GlobalKey();
+  final page2Key = GlobalKey();
+  final page3Key = GlobalKey();
+
   @override
   Widget build(final BuildContext context) {
     return MaterialApp(
       home: Scaffold(
         appBar: AppBar(title: const Text('Example')),
         body: LazyLoadIndexedStack(
+          key: indexStackKey,
           index: _index,
           children: [
-            Page1(),
-            Page2(),
-            Page3(),
+            Page1(key: page1Key),
+            Page2(key: page2Key),
+            Page3(key: page3Key),
           ],
         ),
         bottomNavigationBar: BottomNavigationBar(
@@ -59,8 +66,13 @@ class _MainPageState extends State<MainPage> {
 }
 
 class Page1 extends StatelessWidget {
+  const Page1({Key? key}) : super(key: key);
+
   @override
   Widget build(final BuildContext context) {
+    String className = (this).runtimeType.toString();
+    print('Build $className $key');
+
     return const Center(
       child: Text('page1'),
     );
@@ -68,8 +80,13 @@ class Page1 extends StatelessWidget {
 }
 
 class Page2 extends StatelessWidget {
+  const Page2({Key? key}) : super(key: key);
+
   @override
   Widget build(final BuildContext context) {
+    String className = (this).runtimeType.toString();
+    print('Build $className $key');
+
     return const Center(
       child: Text('page2'),
     );
@@ -77,8 +94,12 @@ class Page2 extends StatelessWidget {
 }
 
 class Page3 extends StatelessWidget {
+  const Page3({Key? key}) : super(key: key);
   @override
   Widget build(final BuildContext context) {
+    String className = (this).runtimeType.toString();
+    print('Build $className $key');
+
     return const Center(
       child: Text('page3'),
     );

--- a/lib/lazy_load_indexed_stack.dart
+++ b/lib/lazy_load_indexed_stack.dart
@@ -1,6 +1,6 @@
 library lazy_load_indexed_stack;
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 /// An extended IndexedStack that builds the required widget only when it is needed, and returns the pre-built widget when it is needed again.
 class LazyLoadIndexedStack extends StatefulWidget {
@@ -45,26 +45,33 @@ class LazyLoadIndexedStack extends StatefulWidget {
 class _LazyLoadIndexedStackState extends State<LazyLoadIndexedStack> {
   late final List<bool> _alreadyLoaded;
 
+  late List<Widget> _children;
+
+  final stackKey = GlobalKey();
+
   @override
   void initState() {
     super.initState();
 
     _alreadyLoaded = List.filled(widget.children.length, false);
     _alreadyLoaded[widget.index] = true;
+
+    _children = _loadedChildren();
   }
 
   @override
   void didUpdateWidget(final LazyLoadIndexedStack oldWidget) {
-    super.didUpdateWidget(oldWidget);
-
     _alreadyLoaded[widget.index] = true;
+    _children[widget.index] = widget.children[widget.index];
+    super.didUpdateWidget(oldWidget);
   }
 
   @override
   Widget build(final BuildContext context) {
     return IndexedStack(
+      key: stackKey,
       index: widget.index,
-      children: _loadedChildren(),
+      children: _children,
       alignment: widget.alignment,
       textDirection: widget.textDirection,
       sizing: widget.sizing,


### PR DESCRIPTION
Resolves Issue #1 By using a static list of children and updating only the entry that changed, instead of reloading the children on every update. 

Also uses widgets import instead of material, to allow this to be used in a pure Cupertino app.