### PR TITLE
[fix] dynamic generation of children causes  overflow

### DIFF
--- a/lib/lazy_load_indexed_stack.dart
+++ b/lib/lazy_load_indexed_stack.dart
@@ -57,6 +57,10 @@ class LazyLoadIndexedStackState extends State<LazyLoadIndexedStack> {
   void didUpdateWidget(final LazyLoadIndexedStack oldWidget) {
     super.didUpdateWidget(oldWidget);
 
+    if (widget.children.length != oldWidget.children.length) {
+      _children = _initialChildren();
+    }
+
     _children[widget.index] = widget.children[widget.index];
   }
 


### PR DESCRIPTION
If the components within its children are dynamically generated, there might be index errors occurring because the internal children are only built during initialization and are not handled for updates.