### PR TITLE
Add `autoDisposeIndexes` to dispose unused IndexedStack children and rebuild them when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # lazy_load_indexed_stack
 
-A package that extends IndexedStack to allow for lazy loading.
+A package that extends IndexedStack to allow for lazy loading and provides enhanced control for reloading specific child widgets.
 
 ## Motivation
 
@@ -11,15 +11,17 @@ If you use the IndexedStack with bottom navigation, all the widgets specified in
 
 Moreover, if the widget requires API requests or database access, or has a complex UI, the IndexedStack build time will be significant.
 
-Therefore, we created an extended IndexedStack that builds the required widget only when it is needed, and returns the pre-built widget when it is needed again.
+Therefore, we created an extended IndexedStack that builds the required widget only when it is needed, and returns the pre-built widget when it is needed again. With the newly added features, you can now also force specific child widgets to reload or manage widget updates dynamically.
 
 ## Features
 * **Lazy Loading**: The main feature of `LazyLoadIndexedStack` is to build children widgets only when they are needed, reducing initial load time.
 * **Preloading**: With the `preloadIndexes` parameter, you can specify indexes of children that should be built in advance, even if they are not currently visible. This is useful for preloading widgets that are likely to be needed soon.
+* **Forced Reloading**: Using the `forceReloadIndexes` parameter, you can specify which child widgets should be forcibly rebuilt when needed. This is helpful for dynamic data loading or resetting specific widgets.
 
 ## Usage
-You can use `LazyLoadIndexedStack` in the same way as `IndexedStack`.
+You can use `LazyLoadIndexedStack` in the same way as `IndexedStack`, with additional options for preloading and forced reloading.
 
+### Basic Example
 ```dart
 class MainPage extends StatefulWidget {
   @override
@@ -36,11 +38,12 @@ class _MainPageState extends State<MainPage> {
         body: LazyLoadIndexedStack(
           index: _index,
           preloadIndexes: const [3],
+          forceReloadIndexes: const [1, 2], // Force reload for index 1 and 2
           children: [
             Page1(),
-            Page2(),
-            Page3(),
-            Page4(), // index3 is preloaded
+            Page2(), // index 1 will be reloaded as specified
+            Page3(), // index 2 will also be reloaded
+            Page4(), // index 3 is preloaded
           ],
         ),
         bottomNavigationBar: BottomNavigationBar(

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ A package that extends IndexedStack to allow for lazy loading and provides enhan
 
 ## Motivation
 
-If you use the IndexedStack with bottom navigation, all the widgets specified in the children of the IndexedStack will be built.
+If you use the IndexedStack with bottom navigation, all the widgets specified in the children of the IndexedStack will be built.  
 
-Moreover, if the widget requires API requests or database access, or has a complex UI, the IndexedStack build time will be significant.
+Moreover, if the widget requires API requests or database access, or has a complex UI, the IndexedStack build time will be significant.  
 
-Therefore, we created an extended IndexedStack that builds the required widget only when it is needed, and returns the pre-built widget when it is needed again. With the newly added features, you can now also force specific child widgets to reload or manage widget updates dynamically.
+Therefore, we created an extended IndexedStack that builds the required widget only when it is needed and returns the pre-built widget when it is needed again.
 
 ## Features
 * **Lazy Loading**: The main feature of `LazyLoadIndexedStack` is to build children widgets only when they are needed, reducing initial load time.
 * **Preloading**: With the `preloadIndexes` parameter, you can specify indexes of children that should be built in advance, even if they are not currently visible. This is useful for preloading widgets that are likely to be needed soon.
-* **Forced Reloading**: Using the `forceReloadIndexes` parameter, you can specify which child widgets should be forcibly rebuilt when needed. This is helpful for dynamic data loading or resetting specific widgets.
+* **Auto Disposal**: The `autoDisposeIndexes` parameter allows specific children to be automatically disposed of when they are no longer visible. When these children are accessed again, they will be rebuilt from scratch. This is useful for cases where widgets hold significant state or require resetting when revisited.
 
 ## Usage
-You can use `LazyLoadIndexedStack` in the same way as `IndexedStack`, with additional options for preloading and forced reloading.
+You can use `LazyLoadIndexedStack` in the same way as `IndexedStack`, with additional options for preloading and auto dispose.
 
 ### Basic Example
 ```dart
@@ -38,11 +38,11 @@ class _MainPageState extends State<MainPage> {
         body: LazyLoadIndexedStack(
           index: _index,
           preloadIndexes: const [3],
-          forceReloadIndexes: const [1, 2], // Force reload for index 1 and 2
+          autoDisposeIndexes: const [1, 2],
           children: [
             Page1(),
-            Page2(), // index 1 will be reloaded as specified
-            Page3(), // index 2 will also be reloaded
+            Page2(), // index 1 will be auto dispose
+            Page3(), // index 2 will also auto dispose
             Page4(), // index 3 is preloaded
           ],
         ),

--- a/lib/lazy_load_indexed_stack.dart
+++ b/lib/lazy_load_indexed_stack.dart
@@ -1,5 +1,3 @@
-library lazy_load_indexed_stack;
-
 import 'package:flutter/widgets.dart';
 
 /// An extended IndexedStack that builds the required widget only when it is needed, and returns the pre-built widget when it is needed again.
@@ -9,6 +7,9 @@ class LazyLoadIndexedStack extends StatefulWidget {
 
   /// The indexes of children that should be preloaded.
   final List<int> preloadIndexes;
+
+  /// The indexes of children that should be forcibly reloaded.
+  final List<int> forceReloadIndexes;
 
   /// Same as alignment attribute of original IndexedStack.
   final AlignmentGeometry alignment;
@@ -33,6 +34,7 @@ class LazyLoadIndexedStack extends StatefulWidget {
     super.key,
     Widget? unloadWidget,
     this.preloadIndexes = const [],
+    this.forceReloadIndexes = const [],
     this.alignment = AlignmentDirectional.topStart,
     this.sizing = StackFit.loose,
     this.textDirection,
@@ -65,6 +67,8 @@ class LazyLoadIndexedStackState extends State<LazyLoadIndexedStack> {
       _children = _initialChildren();
     }
 
+    _children = _updateChildrenForReload();
+
     _children[widget.index] = widget.children[widget.index];
   }
 
@@ -89,6 +93,19 @@ class LazyLoadIndexedStackState extends State<LazyLoadIndexedStack> {
         return childWidget;
       } else {
         return widget.unloadWidget;
+      }
+    }).toList();
+  }
+
+  List<Widget> _updateChildrenForReload() {
+    return widget.children.asMap().entries.map((entry) {
+      final index = entry.key;
+      final childWidget = entry.value;
+
+      if (index != widget.index && widget.forceReloadIndexes.contains(index)) {
+        return widget.unloadWidget;
+      } else {
+        return childWidget;
       }
     }).toList();
   }

--- a/lib/lazy_load_indexed_stack.dart
+++ b/lib/lazy_load_indexed_stack.dart
@@ -8,8 +8,8 @@ class LazyLoadIndexedStack extends StatefulWidget {
   /// The indexes of children that should be preloaded.
   final List<int> preloadIndexes;
 
-  /// The indexes of children that should be forcibly reloaded.
-  final List<int> forceReloadIndexes;
+  /// The indexes of children that should be automatically disposed and rebuilt when accessed again.
+  final List<int> autoDisposeIndexes;
 
   /// Same as alignment attribute of original IndexedStack.
   final AlignmentGeometry alignment;
@@ -34,7 +34,7 @@ class LazyLoadIndexedStack extends StatefulWidget {
     super.key,
     Widget? unloadWidget,
     this.preloadIndexes = const [],
-    this.forceReloadIndexes = const [],
+    this.autoDisposeIndexes = const [],
     this.alignment = AlignmentDirectional.topStart,
     this.sizing = StackFit.loose,
     this.textDirection,
@@ -67,7 +67,7 @@ class LazyLoadIndexedStackState extends State<LazyLoadIndexedStack> {
       _children = _initialChildren();
     }
 
-    _children = _updateChildrenForReload();
+    _children = _updateChildrenForAutoDispose();
 
     _children[widget.index] = widget.children[widget.index];
   }
@@ -97,12 +97,12 @@ class LazyLoadIndexedStackState extends State<LazyLoadIndexedStack> {
     }).toList();
   }
 
-  List<Widget> _updateChildrenForReload() {
+  List<Widget> _updateChildrenForAutoDispose() {
     return widget.children.asMap().entries.map((entry) {
       final index = entry.key;
       final childWidget = entry.value;
 
-      if (index != widget.index && widget.forceReloadIndexes.contains(index)) {
+      if (index != widget.index && widget.autoDisposeIndexes.contains(index)) {
         return widget.unloadWidget;
       } else {
         return childWidget;


### PR DESCRIPTION
- Added a new property, `forceReloadIndexes`, to enable forced reloading of specific child widgets each time they are displayed.

- Introduced a `_updateChildrenForReload` method to manage widget updates, ensuring proper cleanup and handling for child elements.

- Enhanced LazyIndexedStack functionality to provide fine-grained control over widget rendering and lifecycle management.

These updates make the LazyIndexedStack more flexible and suitable for complex widget management scenarios, such as resource-intensive or frequently updated UI elements.